### PR TITLE
Rename/Split API for openassets

### DIFF
--- a/doc/oap.md
+++ b/doc/oap.md
@@ -5,64 +5,21 @@ It allows issuance and transfer of user-created assets.
 
 The Open Assets Protocol is designed for Bitcoin blockchain, but it is possible to adapt to Tapyrus blockchain.
 
-To support it in electrs, some API should be updated or added.
+To support it in electrs-tapyrus, some API should be added.
 
-## Updated API
-
-### blockchain.scripthash.get_balance
-
-Return the confirmed and unconfirmed balances of a script hash.
-
-#### Signature
-
-blockchain.scripthash.get_balance(scripthash)
-
-scripthash
-
-The script hash as a hexadecimal string.
-
-#### Result
-
-A dictionary with keys confirmed, unconfirmed and assets. The value of confirmed and unconfirmed is the appropriate balance in coin units as a string.
-
-#### Result Example
-
-```
-{
-  "confirmed": "1.03873966",
-  "unconfirmed": "0.236844"
-  "colored": [
-    {
-      "asset_id": "ALn3aK1fSuG27N96UGYB1kUYUpGKRhBuBC",
-      "confirmed_asset_quantity": 100,
-      "unconfirmed_asset_quantity": 10,
-    },
-    {
-      "asset_id": "ALVYPzjZjSLoT4xAHJ7x38RcHWNatP4Mba",
-      "confirmed_asset_quantity": 100,
-      "unconfirmed_asset_quantity": 10,
-    }
-  ],
-  "uncolored": {
-    "confirmed": 1.01,
-    "unconfirmed": 0.0001,
-  }
-}
-```
-
-### blockchain.scripthash.listunspent
+## blockchain.openassets.scripthash.listunspent
 
 Return an ordered list of UTXOs sent to a script hash.
 
-#### Signature
+### Signature
 
-blockchain.scripthash.listunspent(scripthash)
+blockchain.openassets.scripthash.listunspent(scripthash)
 
   scripthash
 
 The script hash as a hexadecimal string.
 
-#### Result
+### Result
 
 A list of unspent outputs in blockchain order. This function takes the mempool into account. Mempool transactions paying to the address are included at the end of the list in an undefined order. Any output that is spent in the mempool does not appear. Each output is a dictionary with the following keys:
 
@@ -91,7 +48,7 @@ A list of unspent outputs in blockchain order. This function takes the mempool i
     The asset quantity of the output as an unsigned integer. 0 if the utxo is uncolored.
 
 
-#### Result Example
+### Result Example
 
 ```
 [
@@ -114,100 +71,16 @@ A list of unspent outputs in blockchain order. This function takes the mempool i
 ]
 ```
 
-### blockchain.transaction.get
-
-Return a raw transaction.
-
-#### Signature
-
-blockchain.transaction.get(tx_hash, verbose=false, merkle=false)
-
-tx_hash
-
-The transaction hash as a hexadecimal string.
-verbose
-
-Whether a verbose coin-specific response is required.
-
-#### Result
-
-If verbose is false:
-
-The raw transaction as a hexadecimal string.
-
-If verbose is true:
-
-The result is a coin-specific dictionary – whatever the coin daemon returns when asked for a verbose form of the raw transaction.
-
-#### Example Results
-
-When verbose is false:
-
-```
-"01000000015bb9142c960a838329694d3fe9ba08c2a6421c5158d8f7044cb7c48006c1b48"
-"4000000006a4730440220229ea5359a63c2b83a713fcc20d8c41b20d48fe639a639d2a824"
-"6a137f29d0fc02201de12de9c056912a4e581a62d12fb5f43ee6c08ed0238c32a1ee76921"
-"3ca8b8b412103bcf9a004f1f7a9a8d8acce7b51c983233d107329ff7c4fb53e44c855dbe1"
-"f6a4feffffff02c6b68200000000001976a9141041fb024bd7a1338ef1959026bbba86006"
-"4fe5f88ac50a8cf00000000001976a91445dac110239a7a3814535c15858b939211f85298"
-"88ac61ee0700"
-```
-
-When verbose is true:
-
-```
-{
-  "blockhash": "0000000000000000015a4f37ece911e5e3549f988e855548ce7494a0a08b2ad6",
-  "blocktime": 1520074861,
-  "confirmations": 679,
-  "hash": "36a3692a41a8ac60b73f7f41ee23f5c917413e5b2fad9e44b34865bd0d601a3d",
-  "hex": "01000000015bb9142c960a838329694d3fe9ba08c2a6421c5158d8f7044cb7c48006c1b484000000006a4730440220229ea5359a63c2b83a713fcc20d8c41b20d48fe639a639d2a8246a137f29d0fc02201de12de9c056912a4e581a62d12fb5f43ee6c08ed0238c32a1ee769213ca8b8b412103bcf9a004f1f7a9a8d8acce7b51c983233d107329ff7c4fb53e44c855dbe1f6a4feffffff02c6b68200000000001976a9141041fb024bd7a1338ef1959026bbba860064fe5f88ac50a8cf00000000001976a91445dac110239a7a3814535c15858b939211f8529888ac61ee0700",
-  "locktime": 519777,
-  "size": 225,
-  "time": 1520074861,
-  "txid": "36a3692a41a8ac60b73f7f41ee23f5c917413e5b2fad9e44b34865bd0d601a3d",
-  "version": 1,
-  "vin": [ {
-    "scriptSig": {
-      "asm": "30440220229ea5359a63c2b83a713fcc20d8c41b20d48fe639a639d2a8246a137f29d0fc02201de12de9c056912a4e581a62d12fb5f43ee6c08ed0238c32a1ee769213ca8b8b[ALL|FORKID] 03bcf9a004f1f7a9a8d8acce7b51c983233d107329ff7c4fb53e44c855dbe1f6a4",
-      "hex": "4730440220229ea5359a63c2b83a713fcc20d8c41b20d48fe639a639d2a8246a137f29d0fc02201de12de9c056912a4e581a62d12fb5f43ee6c08ed0238c32a1ee769213ca8b8b412103bcf9a004f1f7a9a8d8acce7b51c983233d107329ff7c4fb53e44c855dbe1f6a4"
-    },
-    "sequence": 4294967294,
-    "txid": "84b4c10680c4b74c04f7d858511c42a6c208bae93f4d692983830a962c14b95b",
-    "vout": 0}],
-  "vout": [ { "n": 0,
-             "scriptPubKey": { "addresses": [ "12UxrUZ6tyTLoR1rT1N4nuCgS9DDURTJgP"],
-                               "asm": "OP_DUP OP_HASH160 1041fb024bd7a1338ef1959026bbba860064fe5f OP_EQUALVERIFY OP_CHECKSIG",
-                               "hex": "76a9141041fb024bd7a1338ef1959026bbba860064fe5f88ac",
-                               "reqSigs": 1,
-                               "type": "pubkeyhash"},
-             "value": 0.0856647},
-           { "n": 1,
-             "scriptPubKey": { "addresses": [ "17NMgYPrguizvpJmB1Sz62ZHeeFydBYbZJ"],
-                               "asm": "OP_DUP OP_HASH160 45dac110239a7a3814535c15858b939211f85298 OP_EQUALVERIFY OP_CHECKSIG",
-                               "hex": "76a91445dac110239a7a3814535c15858b939211f8529888ac",
-                               "reqSigs": 1,
-                               "type": "pubkeyhash"},
-             "value": 0.1360904,
-             "asset": {
-               "asset_id": "ALVYPzjZjSLoT4xAHJ7x38RcHWNatP4Mba",
-               "asset_quantity": 100
-             }
-            }]}
-```
-
-## New API
-
-### blockchain.scripthash.listcoloredunspent
+## blockchain.openassets.scripthash.listcoloredunspent
 
 Return an ordered list of colored UTXOs sent to a scripthash.
 
-#### Signature
-  blockchain.scripthash.listcoloredunspent(scripthash)
+### Signature
+  blockchain.openassets.scripthash.listcoloredunspent(scripthash)
 
   scripthash: The script hash as a hexadecimal string.
 
-#### Result
+### Result
   A list of colored unspent outputs in blockchain order.
   Each output is a dictionary with the following keys:
   
@@ -235,7 +108,7 @@ Return an ordered list of colored UTXOs sent to a scripthash.
 
   The asset quantity of the output as an unsigned integer.
 
-#### Result Example
+### Result Example
 
 ```
 [
@@ -262,16 +135,16 @@ Return an ordered list of colored UTXOs sent to a scripthash.
 ]
 ```
 
-### blockchain.scripthash.listuncoloredunspent
+## blockchain.openassets.scripthash.listuncoloredunspent
 
 Return an ordered list of uncolored UTXOs sent to a scripthash.
 
-#### Signature
-  blockchain.scripthash.listuncoloredunspent(scripthash)
+### Signature
+  blockchain.openassets.scripthash.listuncoloredunspent(scripthash)
 
   scripthash: The script hash as a hexadecimal string.
 
-#### Result
+### Result
   A list of uncolored unspent outputs in blockchain order.
   Each output is a dictionary with the following keys:
   
@@ -291,7 +164,7 @@ Return an ordered list of uncolored UTXOs sent to a scripthash.
 
   The output’s value in minimum coin units (satoshis).
 
-#### Result Example
+### Result Example
 
 ```
 [

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1,0 +1,377 @@
+Electrum Protocol for Electrs-Tapyrus
+=====================================
+
+This document describes avaliable APIs in electrs-tapyrus
+
+electrs-tapyrus is based on electrs which supports Electrum Protocol, so almost all APIs are available as is.
+
+In this document, we detail about the APIs which have differences from original APIs.
+
+For detail of original APIs, see [Electrum Protocol](https://electrumx.readthedocs.io/en/latest/protocol.html)
+
+==================
+ Protocol Methods
+==================
+
+
+blockchain.scripthash.get_balance
+=================================
+
+Return the confirmed and unconfirmed balances of a :ref:`script hash
+<script hashes>`.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.get_balance(scripthash)
+  .. versionadded:: 1.1
+
+  *scripthash*
+
+    The script hash as a hexadecimal string.
+
+**Result**
+
+  An array of dictionary with keys `confirmed`, `color_id`, and `unconfirmed`.  The value of
+  each is the appropriate balance in coin units as a string.
+
+**Result Example**
+
+::
+
+  [{
+    "confirmed": "1.03873966",
+    "unconfirmed": "0.236844"
+  },{
+    "color_id": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46"
+    "confirmed": "1",
+    "unconfirmed": "0"
+  },{
+    "color_id": "c1c4d56b5da93862de658dbc26f8f0585668609ad3f3416543a6aa81d4dfb7cc08"
+    "confirmed": "100",
+    "unconfirmed": "1"
+  }]
+
+blockchain.scripthash.get_history
+=================================
+
+Return the confirmed and unconfirmed history of a :ref:`script hash
+<script hashes>`.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.get_history(scripthash)
+  .. versionadded:: 1.1
+
+  *scripthash* 
+
+    The script hash as a hexadecimal string.
+
+**Result**
+
+  A list of confirmed transactions in blockchain order, with the
+  output of :func:`blockchain.scripthash.get_mempool` appended to the
+  list.  Each confirmed transaction is a dictionary with the following
+  keys:
+
+  * *height*
+
+    The integer height of the block the transaction was confirmed in.
+
+  * *tx_hash*
+
+    The transaction hash in hexadecimal.
+
+  See :func:`blockchain.scripthash.get_mempool` for how mempool
+  transactions are returned.
+
+**Result Examples**
+
+::
+
+  [
+    {
+      "height": 200004,
+      "tx_hash": "acc3758bd2a26f869fcc67d48ff30b96464d476bca82c1cd6656e7d506816412"
+    },
+    {
+      "height": 215008,
+      "tx_hash": "f3e1bf48975b8d6060a9de8884296abb80be618dc00ae3cb2f6cee3085e09403"
+    },
+    {
+      "height": 215010,
+      "tx_hash": "f3e1bf48975b8d6060a9de8884296abb80be618dc00ae3cb2f6cee3085e09403",
+      "color_id": "c1c4d56b5da93862de658dbc26f8f0585668609ad3f3416543a6aa81d4dfb7cc08"
+    }
+  ]
+
+::
+
+  [
+    {
+      "fee": 20000,
+      "height": 0,
+      "tx_hash": "9fbed79a1e970343fcd39f4a2d830a6bde6de0754ed2da70f489d0303ed558ec"
+    }
+  ]
+
+blockchain.scripthash.get_mempool
+=================================
+
+Return the unconfirmed transactions of a :ref:`script hash <script
+hashes>`.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.get_mempool(scripthash)
+  .. versionadded:: 1.1
+
+  *scripthash*
+
+    The script hash as a hexadecimal string.
+
+**Result**
+
+  A list of mempool transactions in arbitrary order.  Each mempool
+  transaction is a dictionary with the following keys:
+
+  * *height*
+
+    ``0`` if all inputs are confirmed, and ``-1`` otherwise.
+
+  * *tx_hash*
+
+    The transaction hash in hexadecimal.
+
+  * *fee*
+
+    The transaction fee in minimum coin units (satoshis).
+
+**Result Example**
+
+::
+
+  [
+    {
+      "tx_hash": "45381031132c57b2ff1cbe8d8d3920cf9ed25efd9a0beb764bdb2f24c7d1c7e3",
+      "height": 0,
+      "fee": 24310
+    },
+    {
+      "tx_hash": "acc3758bd2a26f869fcc67d48ff30b96464d476bca82c1cd6656e7d506816412",
+      "height": 0,
+      "fee": 10000,
+      "color_id": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46"
+    }
+  ]
+
+
+blockchain.scripthash.listunspent
+=================================
+
+Return an ordered list of UTXOs sent to a script hash including native token(TPC) and colored token.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.listunspent(scripthash)
+  .. versionadded:: 1.1
+
+  *scripthash*
+
+    The script hash as a hexadecimal string.
+
+**Result**
+
+  A list of unspent outputs in blockchain order.  This function takes
+  the mempool into account.  Mempool transactions paying to the
+  address are included at the end of the list in an undefined order.
+  Any output that is spent in the mempool does not appear.  Each
+  output is a dictionary with the following keys:
+
+  * *height*
+
+    The integer height of the block the transaction was confirmed in.
+    ``0`` if the transaction is in the mempool.
+
+  * *tx_pos*
+
+    The zero-based index of the output in the transaction's list of
+    outputs.
+
+  * *tx_hash*
+
+    The output's transaction hash as a hexadecimal string.
+
+  * *value*
+
+    The output's value in minimum coin units (tapyrus).
+
+  * *color_id*
+
+    The color identifier of the output for colored coin.
+
+**Result Example**
+
+::
+
+  [
+    {
+      "tx_pos": 0,
+      "value": 45318048,
+      "tx_hash": "9f2c45a12db0144909b5db269415f7319179105982ac70ed80d76ea79d923ebf",
+      "height": 437146,
+      "color_id": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46"
+    },
+    {
+      "tx_pos": 0,
+      "value": 919195,
+      "tx_hash": "3d2290c93436a3e964cfc2f0950174d8847b1fbe3946432c4784e168da0f019f",
+      "height": 441696,
+    }
+  ]
+
+blockchain.scripthash.listcoloredunspent
+========================================
+
+
+Return an ordered list of colored UTXOs sent to a script hash.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.listcoloredunspent(scripthash, color_id = '000000000000000000000000000000000000000000000000000000000000000000')
+
+  *scripthash*
+
+    The script hash as a hexadecimal string.
+
+  *color_id*
+
+    The color identifier as a hexadecimal string. if color_id is not specified, return all colored coin associated with this scripthash.
+
+**Result**
+
+  A list of colored unspent outputs in blockchain order.  This function takes
+  the mempool into account.  Mempool transactions paying to the
+  address are included at the end of the list in an undefined order.
+  Any output that is spent in the mempool does not appear.  Each
+  output is a dictionary with the following keys:
+
+  * *height*
+
+    The integer height of the block the transaction was confirmed in.
+    ``0`` if the transaction is in the mempool.
+
+  * *tx_pos*
+
+    The zero-based index of the output in the transaction's list of
+    outputs.
+
+  * *tx_hash*
+
+    The output's transaction hash as a hexadecimal string.
+
+  * *value*
+
+    The output's value in minimum coin units (tapyrus).
+
+  * *color_id*
+
+    The color identifier of the output for colored coin.
+
+**Result Example**
+
+::
+
+  [
+    {
+      "tx_pos": 0,
+      "value": 45318048,
+      "tx_hash": "9f2c45a12db0144909b5db269415f7319179105982ac70ed80d76ea79d923ebf",
+      "height": 437146,
+      "color_id": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46"
+    },
+    {
+      "tx_pos": 0,
+      "value": 919195,
+      "tx_hash": "3d2290c93436a3e964cfc2f0950174d8847b1fbe3946432c4784e168da0f019f",
+      "height": 441696,
+      "color_id": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46"
+    }
+  ]
+
+blockchain.scripthash.listuncoloredunspent
+==========================================
+
+
+Return an ordered list of uncolored (i.e. Native token) UTXOs sent to a script hash.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.listuncoloredunspent(scripthash)
+
+  *scripthash*
+
+    The script hash as a hexadecimal string.
+
+**Result**
+
+  A list of uncolored unspent outputs in blockchain order.  This function takes
+  the mempool into account.  Mempool transactions paying to the
+  address are included at the end of the list in an undefined order.
+  Any output that is spent in the mempool does not appear.  Each
+  output is a dictionary with the following keys:
+
+  * *height*
+
+    The integer height of the block the transaction was confirmed in.
+    ``0`` if the transaction is in the mempool.
+
+  * *tx_pos*
+
+    The zero-based index of the output in the transaction's list of
+    outputs.
+
+  * *tx_hash*
+
+    The output's transaction hash as a hexadecimal string.
+
+  * *value*
+
+    The output's value in minimum coin units (tapyrus).
+
+**Result Example**
+
+::
+
+  [
+    {
+      "tx_pos": 0,
+      "value": 45318048,
+      "tx_hash": "9f2c45a12db0144909b5db269415f7319179105982ac70ed80d76ea79d923ebf",
+      "height": 437146,
+    },
+    {
+      "tx_pos": 0,
+      "value": 919195,
+      "tx_hash": "3d2290c93436a3e964cfc2f0950174d8847b1fbe3946432c4784e168da0f019f",
+      "height": 441696,
+    }
+  ]
+
+================================
+Support for open assets protocol
+================================
+
+The Open Assets Protocol is a simple and powerful protocol. 
+It allows issuance and transfer of user-created assets.
+
+The Open Assets Protocol is designed for Bitcoin blockchain, but it is possible to adapt to Tapyrus blockchain.
+
+To support it in electrs, some APIs should be added.
+
+blockchain.open_assets.scripthash.listcoloredunspent
+====================================================
+
+
+blockchain.open_assets.scripthash.listuncoloredunspent
+======================================================
+

--- a/src/query.rs
+++ b/src/query.rs
@@ -69,13 +69,14 @@ impl FundingOutput {
 }
 
 impl FundingOutput {
-    pub fn to_json(&self) -> Value {
-        if self.asset.is_none() {
+    pub fn to_json(&self, open_assets: bool) -> Value {
+        if open_assets && self.asset.is_some() {
             json!({
                 "height": self.height,
                 "tx_pos": self.output_index,
                 "tx_hash": self.txn_id.to_hex(),
                 "value": self.value,
+                "asset": self.asset.as_ref().expect("failed to read asset"),
             })
         } else {
             json!({
@@ -83,7 +84,6 @@ impl FundingOutput {
                 "tx_pos": self.output_index,
                 "tx_hash": self.txn_id.to_hex(),
                 "value": self.value,
-                "asset": self.asset.as_ref().expect("failed to read asset"),
             })
         }
     }
@@ -883,7 +883,7 @@ mod tests {
             Txid::from_str("0000000000000000000000000000000000000000000000000000000000000000")
                 .unwrap();
         let output = FundingOutput::build(txid, 0, 1, 2, None);
-        let value = output.to_json();
+        let value = output.to_json(false);
         assert_json_eq!(
             value,
             json!({
@@ -901,7 +901,7 @@ mod tests {
             Txid::from_str("0000000000000000000000000000000000000000000000000000000000000000")
                 .unwrap();
         let output = FundingOutput::build(txid, 0, 1, 2, asset_1(3, url_metadata()));
-        let value = output.to_json();
+        let value = output.to_json(true);
         assert_json_eq!(
             value,
             json!({

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -67,27 +67,37 @@ fn unspent_from_status(status: &Status) -> Value {
         status
             .unspent()
             .into_iter()
-            .map(|out| out.to_json())
+            .map(|out| out.to_json(false))
             .collect()
     ))
 }
 
-fn colored_unspent_from_status(status: &Status) -> Value {
+fn open_assets_unspent_from_status(status: &Status) -> Value {
+    json!(Value::Array(
+        status
+            .unspent()
+            .into_iter()
+            .map(|out| out.to_json(true))
+            .collect()
+    ))
+}
+
+fn open_assets_colored_unspent_from_status(status: &Status) -> Value {
     json!(Value::Array(
         status
             .colored_unspent()
             .into_iter()
-            .map(|out| out.to_json())
+            .map(|out| out.to_json(true))
             .collect()
     ))
 }
 
-fn uncolored_unspent_from_status(status: &Status) -> Value {
+fn open_assets_uncolored_unspent_from_status(status: &Status) -> Value {
     json!(Value::Array(
         status
             .uncolored_unspent()
             .into_iter()
-            .map(|out| out.to_json())
+            .map(|out| out.to_json(true))
             .collect()
     ))
 }
@@ -257,16 +267,21 @@ impl Connection {
         Ok(unspent_from_status(&self.query.status(&script_hash[..])?))
     }
 
-    fn blockchain_scripthash_listcoloredunspent(&self, params: &[Value]) -> Result<Value> {
+    fn blockchain_openassets_scripthash_listunspent(&self, params: &[Value]) -> Result<Value> {
         let script_hash = script_hash_from_value(params.get(0)).chain_err(|| "bad script_hash")?;
-        Ok(colored_unspent_from_status(
+        Ok(open_assets_unspent_from_status(&self.query.status(&script_hash[..])?))
+    }
+
+    fn blockchain_openassets_scripthash_listcoloredunspent(&self, params: &[Value]) -> Result<Value> {
+        let script_hash = script_hash_from_value(params.get(0)).chain_err(|| "bad script_hash")?;
+        Ok(open_assets_colored_unspent_from_status(
             &self.query.status(&script_hash[..])?,
         ))
     }
 
-    fn blockchain_scripthash_listuncoloredunspent(&self, params: &[Value]) -> Result<Value> {
+    fn blockchain_openassets_scripthash_listuncoloredunspent(&self, params: &[Value]) -> Result<Value> {
         let script_hash = script_hash_from_value(params.get(0)).chain_err(|| "bad script_hash")?;
-        Ok(uncolored_unspent_from_status(
+        Ok(open_assets_uncolored_unspent_from_status(
             &self.query.status(&script_hash[..])?,
         ))
     }
@@ -340,11 +355,12 @@ impl Connection {
             "blockchain.scripthash.get_balance" => self.blockchain_scripthash_get_balance(&params),
             "blockchain.scripthash.get_history" => self.blockchain_scripthash_get_history(&params),
             "blockchain.scripthash.listunspent" => self.blockchain_scripthash_listunspent(&params),
-            "blockchain.scripthash.listcoloredunspent" => {
-                self.blockchain_scripthash_listcoloredunspent(&params)
+            "blockchain.openassets.scripthash.listunspent" => self.blockchain_openassets_scripthash_listunspent(&params),
+            "blockchain.openassets.scripthash.listcoloredunspent" => {
+                self.blockchain_openassets_scripthash_listcoloredunspent(&params)
             }
-            "blockchain.scripthash.listuncoloredunspent" => {
-                self.blockchain_scripthash_listuncoloredunspent(&params)
+            "blockchain.open_assets.scripthash.listuncoloredunspent" => {
+                self.blockchain_openassets_scripthash_listuncoloredunspent(&params)
             }
             "blockchain.scripthash.subscribe" => self.blockchain_scripthash_subscribe(&params),
             "blockchain.transaction.broadcast" => self.blockchain_transaction_broadcast(&params),

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -269,17 +269,25 @@ impl Connection {
 
     fn blockchain_openassets_scripthash_listunspent(&self, params: &[Value]) -> Result<Value> {
         let script_hash = script_hash_from_value(params.get(0)).chain_err(|| "bad script_hash")?;
-        Ok(open_assets_unspent_from_status(&self.query.status(&script_hash[..])?))
+        Ok(open_assets_unspent_from_status(
+            &self.query.status(&script_hash[..])?,
+        ))
     }
 
-    fn blockchain_openassets_scripthash_listcoloredunspent(&self, params: &[Value]) -> Result<Value> {
+    fn blockchain_openassets_scripthash_listcoloredunspent(
+        &self,
+        params: &[Value],
+    ) -> Result<Value> {
         let script_hash = script_hash_from_value(params.get(0)).chain_err(|| "bad script_hash")?;
         Ok(open_assets_colored_unspent_from_status(
             &self.query.status(&script_hash[..])?,
         ))
     }
 
-    fn blockchain_openassets_scripthash_listuncoloredunspent(&self, params: &[Value]) -> Result<Value> {
+    fn blockchain_openassets_scripthash_listuncoloredunspent(
+        &self,
+        params: &[Value],
+    ) -> Result<Value> {
         let script_hash = script_hash_from_value(params.get(0)).chain_err(|| "bad script_hash")?;
         Ok(open_assets_uncolored_unspent_from_status(
             &self.query.status(&script_hash[..])?,
@@ -355,7 +363,9 @@ impl Connection {
             "blockchain.scripthash.get_balance" => self.blockchain_scripthash_get_balance(&params),
             "blockchain.scripthash.get_history" => self.blockchain_scripthash_get_history(&params),
             "blockchain.scripthash.listunspent" => self.blockchain_scripthash_listunspent(&params),
-            "blockchain.openassets.scripthash.listunspent" => self.blockchain_openassets_scripthash_listunspent(&params),
+            "blockchain.openassets.scripthash.listunspent" => {
+                self.blockchain_openassets_scripthash_listunspent(&params)
+            }
             "blockchain.openassets.scripthash.listcoloredunspent" => {
                 self.blockchain_openassets_scripthash_listcoloredunspent(&params)
             }


### PR DESCRIPTION
We are going to support 1st layer colored coin feature in Tapyrus Core v0.5.0.
(https://github.com/chaintope/tapyrus-core/issues/77)

Electrs-tapyrus has already support colored coin feature based on Open Assets Protocol.
After Tapyrus Core v0.5.0, we should distinguish these two specifications about colored coins.
At first I created this PR to rename APIs about colored coin feature so that name of APIs does not conflict between Open Assets and Native coin.

* blockchain.scripthash.listcoloredunspent -> blockchain.openassets.scripthash.listcoloredunspent
* blockchain.scripthash.listuncoloredunspent -> blockchain.openassets.scripthash.listuncoloredunspent
* blockchain.scripthash.listunspent is split into two. 
    * openassets version is renamed to blockchain.openassets.scripthash.listunspent


And unimplemented parts removed from document.