### PR TITLE
Fix/daemon path in dev mode

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -249,11 +249,6 @@ impl Config {
             ResolvAddr::resolve_or_exit,
         );
 
-        match config.network {
-            Network::Prod => (),
-            Network::Dev => config.daemon_dir.push("testnet3"),
-        }
-
         let cookie_getter =
             create_cookie_getter(config.cookie, config.cookie_file, &config.daemon_dir);
 


### PR DESCRIPTION
For Tapyrus, The default daemon path is `~/.tapyrus/prod-{networkid}` or `~/.tapyrus/dev-{networkid}`
This pull request fixes daemon path for Dev mode.
